### PR TITLE
Do matrix computations on the cpu

### DIFF
--- a/examples/gfx_quads.go
+++ b/examples/gfx_quads.go
@@ -53,8 +53,11 @@ func main() {
 		quads[11].SetScale(mgl32.Vec2{animationScale, animationScale})
 		quads[11].SetAngle(animationAngle)
 	}, func() {
-		for _, q := range quads {
-			q.EnqueueForDrawing(app.Context)
+		for i:=0; i<2000; i++ {
+			for _, q := range quads {
+				q.EnqueueForDrawing(app.Context)
+			}
 		}
+		println("FPS: ", app.FpsCounter.FPS())
 	})
 }

--- a/examples/gfx_quads.go
+++ b/examples/gfx_quads.go
@@ -53,11 +53,8 @@ func main() {
 		quads[11].SetScale(mgl32.Vec2{animationScale, animationScale})
 		quads[11].SetAngle(animationAngle)
 	}, func() {
-		for i:=0; i<2000; i++ {
-			for _, q := range quads {
-				q.EnqueueForDrawing(app.Context)
-			}
+		for _, q := range quads {
+			q.EnqueueForDrawing(app.Context)
 		}
-		println("FPS: ", app.FpsCounter.FPS())
 	})
 }

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-gl/gl/v4.1-core/gl"
 	"runtime"
 	g "gojira2d/pkg/graphics"
+	"gojira2d/pkg/utils"
 )
 
 const (
@@ -16,15 +17,17 @@ const (
 type App struct {
 	Window  *glfw.Window
 	Context *g.Context
+	FpsCounter *utils.FPSCounter
 }
 
 func InitApp(windowWidth int, windowHeight int, windowCentered bool, windowTitle string) (*App) {
 	runtime.LockOSThread()
-	core := &App{}
-	core.Window = initWindow(windowWidth, windowHeight, windowTitle)
-	core.Context = &g.Context{}
-	core.Context.SetOrtho2DProjection(windowWidth, windowHeight, 1, windowCentered)
-	return core
+	app := &App{}
+	app.Window = initWindow(windowWidth, windowHeight, windowTitle)
+	app.Context = &g.Context{}
+	app.Context.SetOrtho2DProjection(windowWidth, windowHeight, 1, windowCentered)
+	app.FpsCounter = &utils.FPSCounter{}
+	return app
 }
 
 func TerminateApp() {
@@ -64,22 +67,24 @@ func initWindow(width, height int, title string) *glfw.Window {
 	return window
 }
 
-func (c *App) MainLoop(
+func (a *App) MainLoop(
 	update func(float64),
 	render func(),
 ) {
 	var newTime, oldTime float64
-	for !c.Window.ShouldClose() {
+	for !a.Window.ShouldClose() {
 		newTime = glfw.GetTime()
-		update(newTime - oldTime)
+		deltaTime := newTime - oldTime
+		update(deltaTime)
+		a.FpsCounter.Update(deltaTime, 1)
 		oldTime = newTime
 
-		c.Context.Clear()
+		a.Context.Clear()
 		render()
-		c.Context.RenderDrawableList()
-		c.Context.EraseDrawableList()
+		a.Context.RenderDrawableList()
+		a.Context.EraseDrawableList()
 
 		glfw.PollEvents()
-		c.Window.SwapBuffers()
+		a.Window.SwapBuffers()
 	}
 }

--- a/pkg/graphics/primitive_2d.go
+++ b/pkg/graphics/primitive_2d.go
@@ -9,73 +9,87 @@ import (
 
 const FLOAT32_SIZE = 4
 
-type Matrix struct {
-	Matrix mgl32.Mat4
-	Dirty  bool
+type ModelMatrix struct {
+	mgl32.Mat4
+	size        mgl32.Mat4
+	translation mgl32.Mat4
+	rotation    mgl32.Mat4
+	scale       mgl32.Mat4
+	anchor      mgl32.Mat4
+	dirty       bool
 }
 
 type Primitive2D struct {
 	Primitive
-	position          mgl32.Vec3
-	scale             mgl32.Vec2
-	size              mgl32.Vec2
-	anchor            mgl32.Vec2
-	angle             float32
-	flipX             bool
-	flipY             bool
-	color             Color
-	matrixSize        Matrix
-	matrixTranslation Matrix
-	matrixRotation    Matrix
-	matrixScale       Matrix
-	matrixAnchor      Matrix
+	position    mgl32.Vec3
+	scale       mgl32.Vec2
+	size        mgl32.Vec2
+	anchor      mgl32.Vec2
+	angle       float32
+	flipX       bool
+	flipY       bool
+	color       Color
+	modelMatrix ModelMatrix
 }
 
 func (p *Primitive2D) SetPosition(position mgl32.Vec3) {
 	p.position = position
-	p.matrixTranslation.Dirty = true
+	p.modelMatrix.translation = mgl32.Translate3D(p.position.X(), p.position.Y(), p.position.Z())
+	p.modelMatrix.dirty = true
 }
 
 func (p *Primitive2D) SetAnchor(anchor mgl32.Vec2) {
 	p.anchor = anchor
-	p.matrixAnchor.Dirty = true
+	p.modelMatrix.anchor = mgl32.Translate3D(-p.anchor.X(), -p.anchor.Y(), 0)
+	p.modelMatrix.dirty = true
 }
 
 func (p *Primitive2D) SetAngle(radians float32) {
 	p.angle = radians
-	p.matrixRotation.Dirty = true
-}
-
-func (p *Primitive2D) SetScale(scale mgl32.Vec2) {
-	p.scale = scale
-	p.matrixScale.Dirty = true
+	p.modelMatrix.rotation = mgl32.HomogRotate3DZ(p.angle)
+	p.modelMatrix.dirty = true
 }
 
 func (p *Primitive2D) SetSize(size mgl32.Vec2) {
 	p.size = size
-	p.matrixSize.Dirty = true
+	p.modelMatrix.size = mgl32.Scale3D(p.size.X(), p.size.Y(), 1)
+	p.modelMatrix.dirty = true
+}
+
+func (p *Primitive2D) SetScale(scale mgl32.Vec2) {
+	p.scale = scale
+	p.rebuildScaleMatrix()
 }
 
 func (p *Primitive2D) SetFlipX(flipX bool) {
 	p.flipX = flipX
-	p.matrixScale.Dirty = true
+	p.rebuildScaleMatrix()
 }
 
 func (p *Primitive2D) SetFlipY(flipY bool) {
 	p.flipY = flipY
-	p.matrixScale.Dirty = true
+	p.rebuildScaleMatrix()
 }
 
 func (p *Primitive2D) SetColor(color Color) {
 	p.color = color
 }
 
-func (p *Primitive2D) rebuildMatrices() {
-	p.matrixTranslation.Matrix = mgl32.Translate3D(p.position.X(), p.position.Y(), p.position.Z())
-	p.matrixScale.Matrix = mgl32.Scale3D(p.scale.X(), p.scale.Y(), 1)
-	p.matrixRotation.Matrix = mgl32.HomogRotate3DZ(p.angle)
-	p.matrixSize.Matrix = mgl32.Scale3D(p.size.X(), p.size.Y(), 1)
-	p.matrixAnchor.Matrix = mgl32.Translate3D(-p.anchor.X(), -p.anchor.Y(), 0)
+func (p *Primitive2D) SetUniforms() {
+	p.shaderProgram.SetUniform("color", &p.color)
+	p.shaderProgram.SetUniform("mModel", p.ModelMatrix())
+}
+
+func (p *Primitive2D) SetSizeFromTexture() {
+	p.SetSize(mgl32.Vec2{float32(p.texture.width), float32(p.texture.height)})
+}
+
+func (p *Primitive2D) SetAnchorToCenter() {
+	p.SetAnchor(mgl32.Vec2{p.size[0] / 2.0, p.size[1] / 2.0})
+}
+
+func (p *Primitive2D) EnqueueForDrawing(context *Context) {
+	context.enqueueForDrawing(p)
 }
 
 func (p *Primitive2D) Draw(context *Context) {
@@ -88,66 +102,42 @@ func (p *Primitive2D) Draw(context *Context) {
 	gl.DrawArrays(p.arrayMode, 0, p.arraySize)
 }
 
-func (p *Primitive2D) EnqueueForDrawing(context *Context) {
-	context.enqueueForDrawing(p)
-}
-
-// Texture and shaders are already set when this is called
+// Texture and shaders are already bound when this is called
 func (p *Primitive2D) drawInBatch(context *Context) {
-	// TODO: setup uniforms (including matrices)
 	p.SetUniforms()
 	gl.BindVertexArray(p.vaoId)
 	gl.DrawArrays(p.arrayMode, 0, p.arraySize)
 }
 
-func (p *Primitive2D) SetSizeFromTexture() {
-	p.SetSize(mgl32.Vec2{float32(p.texture.width), float32(p.texture.height)})
+func (p *Primitive2D) rebuildMatrices() {
+	p.modelMatrix.translation = mgl32.Translate3D(p.position.X(), p.position.Y(), p.position.Z())
+	p.modelMatrix.anchor = mgl32.Translate3D(-p.anchor.X(), -p.anchor.Y(), 0)
+	p.modelMatrix.rotation = mgl32.HomogRotate3DZ(p.angle)
+	p.modelMatrix.size = mgl32.Scale3D(p.size.X(), p.size.Y(), 1)
+	p.rebuildScaleMatrix()
+
+	p.modelMatrix.dirty = true
 }
 
-func (p *Primitive2D) SetAnchorToCenter() {
-	p.SetAnchor(mgl32.Vec2{p.size[0] / 2.0, p.size[1] / 2.0})
+func (p *Primitive2D) rebuildScaleMatrix() {
+	scaleX := p.scale.X()
+	if p.flipX {
+		scaleX *= -1
+	}
+	scaleY := p.scale.Y()
+	if p.flipY {
+		scaleY *= -1
+	}
+	p.modelMatrix.scale = mgl32.Scale3D(scaleX, scaleY, 1)
+	p.modelMatrix.dirty = true
 }
 
-func (p *Primitive2D) invalidateMatrices() {
-	p.matrixTranslation.Dirty = true
-	p.matrixSize.Dirty = true
-	p.matrixRotation.Dirty = true
-	p.matrixScale.Dirty = true
-	p.matrixAnchor.Dirty = true
-}
-
-func (p *Primitive2D) SetUniforms() {
-	if p.matrixTranslation.Dirty {
-		p.matrixTranslation.Matrix = mgl32.Translate3D(p.position.X(), p.position.Y(), p.position.Z())
-		p.matrixTranslation.Dirty = false
-		p.shaderProgram.SetUniform("mTranslate", &p.matrixTranslation.Matrix)
+func (p *Primitive2D)ModelMatrix() (*mgl32.Mat4) {
+	if p.modelMatrix.dirty {
+		p.modelMatrix.Mat4 = p.modelMatrix.translation.Mul4(p.modelMatrix.rotation).Mul4(p.modelMatrix.scale).Mul4(p.modelMatrix.anchor).Mul4(p.modelMatrix.size)
+		//p.modelMatrix.Mat4 = p.modelMatrix.translation.Mul4(p.modelMatrix.size)
 	}
-	if p.matrixScale.Dirty {
-		scaleX := p.scale.X()
-		if p.flipX {
-			scaleX *= -1
-		}
-		scaleY := p.scale.Y()
-		if p.flipY {
-			scaleY *= -1
-		}
-		p.matrixScale.Matrix = mgl32.Scale3D(scaleX, scaleY, 1)
-		p.shaderProgram.SetUniform("mScale", &p.matrixScale.Matrix)
-	}
-	if p.matrixSize.Dirty {
-		p.matrixSize.Matrix = mgl32.Scale3D(p.size.X(), p.size.Y(), 1)
-		p.shaderProgram.SetUniform("mSize", &p.matrixSize.Matrix)
-	}
-	if p.matrixRotation.Dirty {
-		p.matrixRotation.Matrix = mgl32.HomogRotate3DZ(p.angle)
-		p.shaderProgram.SetUniform("mRotation", &p.matrixRotation.Matrix)
-	}
-	if p.matrixRotation.Dirty {
-		p.matrixAnchor.Matrix = mgl32.Translate3D(-p.anchor.X(), -p.anchor.Y(), 0)
-		p.shaderProgram.SetUniform("mAnchor", &p.matrixAnchor.Matrix)
-	}
-
-	p.shaderProgram.SetUniform("color", &p.color)
+	return &p.modelMatrix.Mat4
 }
 
 func NewQuadPrimitive(position mgl32.Vec3, size mgl32.Vec2) *Primitive2D {
@@ -156,7 +146,7 @@ func NewQuadPrimitive(position mgl32.Vec3, size mgl32.Vec2) *Primitive2D {
 	q.size = size
 	q.scale = mgl32.Vec2{1, 1}
 	q.shaderProgram = NewShaderProgram(VertexShaderPrimitive2D, "", FragmentShaderTexture)
-	q.invalidateMatrices()
+	q.rebuildMatrices()
 
 	q.arrayMode = gl.TRIANGLE_FAN
 	q.arraySize = 4
@@ -195,7 +185,7 @@ func NewRegularPolygonPrimitive(position mgl32.Vec3, radius float32, numSegments
 	q.size = mgl32.Vec2{radius * 2, radius * 2}
 	q.scale = mgl32.Vec2{1, 1}
 	q.shaderProgram = NewShaderProgram(VertexShaderPrimitive2D, "", FragmentShaderSolidColor)
-	q.invalidateMatrices()
+	q.rebuildMatrices()
 
 	// Vertices
 	vertices := make([]float32, 0, numSegments*2)
@@ -239,7 +229,7 @@ func NewTriangles(
 	p.arraySize = int32(len(vertices) / 2)
 	p.texture = texture
 	p.shaderProgram = shaderProgram
-	p.invalidateMatrices()
+	p.rebuildMatrices()
 
 	gl.GenVertexArrays(1, &p.vaoId)
 	gl.BindVertexArray(p.vaoId)
@@ -276,7 +266,7 @@ func NewPolylinePrimitive(position mgl32.Vec3, points []mgl32.Vec2, closed bool)
 	primitive.size = bottomRight.Sub(topLeft)
 	primitive.scale = mgl32.Vec2{1, 1}
 	primitive.shaderProgram = NewShaderProgram(VertexShaderPrimitive2D, "", FragmentShaderSolidColor)
-	primitive.invalidateMatrices()
+	primitive.rebuildMatrices()
 
 	// Vertices
 	vertices := make([]float32, 0, len(points)*2)
@@ -310,12 +300,8 @@ const (
 	VertexShaderPrimitive2D = `
         #version 410 core
 
+        uniform mat4 mModel;
         uniform mat4 mProjection;
-        uniform mat4 mScale;
-        uniform mat4 mTranslate;
-        uniform mat4 mSize;
-        uniform mat4 mRotation;
-        uniform mat4 mAnchor;
 
         layout(location=0) in vec2 vertex;
         layout(location=1) in vec2 uv;
@@ -323,7 +309,6 @@ const (
         out vec2 uv_out;
 
         void main() {
-			mat4 mModel = mTranslate * mRotation * mScale * mAnchor * mSize;
             vec4 vertex_world = mModel * vec4(vertex, 0, 1);
             gl_Position = mProjection * vertex_world;
             uv_out = uv;

--- a/pkg/utils/fps_counter.go
+++ b/pkg/utils/fps_counter.go
@@ -1,0 +1,23 @@
+package utils
+
+type FPSCounter struct {
+	frames      uint32
+	accumulator float64
+	fps         uint32
+}
+
+// deltaTime: milliseconds since the previous frame
+// updateRate: rate, in seconds, at which the FPS are computed
+func (f *FPSCounter) Update(deltaTime float64, updateRate uint32) {
+	f.frames ++
+	f.accumulator += deltaTime // ms
+	if f.accumulator > float64(updateRate) {
+		f.fps = f.frames / updateRate
+		f.accumulator -= float64(updateRate)
+		f.frames = 0
+	}
+}
+
+func (f *FPSCounter) FPS() (uint32) {
+	return f.fps
+}


### PR DESCRIPTION
The shaders now use mModel only, the concatenation is done on the Primitive code.
I changed the way the dirty state is handled and made a small refactoring.
Also added an FPSCounter struct to test performances... not much changed :)

Next step: reuse the same shaders for the 2d primitives and group drawables by shader as well to reduce the number of shader changes
