### PR TITLE
Making polylines creation more rational

### DIFF
--- a/examples/shapes/main.go
+++ b/examples/shapes/main.go
@@ -17,8 +17,8 @@ func main() {
 		g.NewRegularPolygonPrimitive(mgl32.Vec3{250, 100, 0}, 50, 6, true),
 		g.NewRegularPolygonPrimitive(mgl32.Vec3{400, 100, 0}, 50, 8, false),
 		g.NewRegularPolygonPrimitive(mgl32.Vec3{550, 100, 0}, 50, 12, true),
-		g.NewPolylinePrimitive(mgl32.Vec3{50, 420, 0}, []mgl32.Vec2{{60, 20}, {20, 20}, {20, 70}, {60, 70}, {60, 45}, {40, 45}}, false),
-		g.NewPolylinePrimitive(mgl32.Vec3{110, 420, 0}, []mgl32.Vec2{{0, 0}, {0, 50}, {40, 50}}, false),
+		g.NewPolylinePrimitiveRaw(mgl32.Vec3{50, 420, 0}, []mgl32.Vec2{{20, -20}, {-20, -20}, {-20, 40}, {20, 40}, {20, 10}, {0, 10}}, false),
+		g.NewPolylinePrimitiveRaw(mgl32.Vec3{110, 420, 0}, []mgl32.Vec2{{-20, -20}, {-20, 40}, {20, 40}}, false),
 	}
 
 	for _, p := range primitives {

--- a/pkg/graphics/primitive_2d.go
+++ b/pkg/graphics/primitive_2d.go
@@ -246,34 +246,6 @@ func NewTriangles(
 	return p
 }
 
-// NewPolylinePrimitive creates a primitive from a sequence of points
-func NewPolylinePrimitive(position mgl32.Vec3, points []mgl32.Vec2, closed bool) *Primitive2D {
-	topLeft, bottomRight := utils.GetBoundingBox(points)
-
-	primitive := &Primitive2D{}
-	primitive.position = position
-	primitive.size = bottomRight.Sub(topLeft)
-	primitive.scale = mgl32.Vec2{1, 1}
-	primitive.shaderProgram = NewShaderProgram(VertexShaderBase, "", FragmentShaderSolidColor)
-	primitive.rebuildMatrices()
-
-	// Vertices
-	vertices := make([]float32, 0, len(points)*2)
-	for _, p := range points {
-		// The vertices coordinates are relative to the top left and are scaled by size
-		vertices = append(vertices, (p[0]-topLeft[0])/primitive.size.X(), (p[1]-topLeft[1])/primitive.size.Y())
-	}
-	if closed {
-		// Add the first point again to close the loop
-		vertices = append(vertices, vertices[0], vertices[1])
-	}
-
-	primitive.arrayMode = gl.LINE_STRIP
-	primitive.arraySize = int32(len(vertices) / 2)
-	primitive.SetVertices(vertices)
-	return primitive
-}
-
 // NewPolylinePrimitiveRaw creates a primitive from a sequence of points. The points coordinates are relative to the passed center
 func NewPolylinePrimitiveRaw(center mgl32.Vec3, points []mgl32.Vec2, closed bool) *Primitive2D {
 	primitive := &Primitive2D{}


### PR DESCRIPTION
Moving the shapes example to the new Polyline "Raw".
While working on the box2d debug functions, I realized the polylines were doing too complex computations for nothing. It's much easier to pass all the points relative to the center and avoiding scaling them.
The following step will be to remove the RAW from the name of the function