### PR TITLE
The App doesn't control the camera's centering anymore

### DIFF
--- a/examples/controller_test/main.go
+++ b/examples/controller_test/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	app.Init(640, 480, false, "Controller Test")
+	app.Init(640, 480, "Controller Test")
 	defer app.Terminate()
 
 	var joy input.GameController

--- a/examples/quad/main.go
+++ b/examples/quad/main.go
@@ -7,8 +7,10 @@ import (
 )
 
 func main() {
-	app.Init(640, 480, true, "Quad")
+	app.Init(640, 480, "Quad")
 	defer app.Terminate()
+
+	app.Context.Camera2D.SetCentered(true)
 
 	Quad := g.NewQuadPrimitive(mgl32.Vec3{0, 0, 0}, mgl32.Vec2{200, 200})
 	Quad.SetAnchorToCenter()

--- a/examples/quads/main.go
+++ b/examples/quads/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	app.Init(800, 600, false, "Quads")
+	app.Init(800, 600, "Quads")
 	defer app.Terminate()
 
 	quads := make([]*g.Primitive2D, 0, 12)

--- a/examples/shapes/main.go
+++ b/examples/shapes/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	app.Init(640, 480, false, "Shapes")
+	app.Init(640, 480, "Shapes")
 	defer app.Terminate()
 
 	primitives := []*g.Primitive2D{

--- a/examples/text/main.go
+++ b/examples/text/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 func main() {
-	app.Init(800, 600, false, "Text")
+	app.Init(800, 600, "Text")
 	app.SetClearColor(graphics.Color{0, 0, 0, 1})
 	defer app.Terminate()
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -36,12 +36,13 @@ func init() {
 	}
 }
 
-func Init(windowWidth int, windowHeight int, windowCentered bool, windowTitle string) {
+// Init initializes the main window
+func Init(windowWidth int, windowHeight int, windowTitle string) {
 	window = initWindow(windowWidth, windowHeight, windowTitle)
 	Context = &g.Context{}
-	Context.Camera2D = g.NewCamera2D(windowWidth, windowHeight, 1, windowCentered)
+	Context.Camera2D = g.NewCamera2D(windowWidth, windowHeight, 1)
 	UIContext = &g.Context{}
-	UIContext.Camera2D = g.NewCamera2D(windowWidth, windowHeight, 1, false)
+	UIContext.Camera2D = g.NewCamera2D(windowWidth, windowHeight, 1)
 	FpsCounter = &utils.FPSCounter{}
 
 	font := ui.NewFontFromFiles(

--- a/pkg/graphics/camera_2d.go
+++ b/pkg/graphics/camera_2d.go
@@ -20,12 +20,11 @@ type Camera2D struct {
 }
 
 // NewCamera2D sets up an orthogonal projection camera
-func NewCamera2D(width int, height int, zoom float32, centered bool) *Camera2D {
+func NewCamera2D(width int, height int, zoom float32) *Camera2D {
 	c := &Camera2D{
-		width:    float32(width),
-		height:   float32(height),
-		zoom:     zoom,
-		centered: centered,
+		width:  float32(width),
+		height: float32(height),
+		zoom:   zoom,
 	}
 	c.far = -2
 	c.near = 2
@@ -52,6 +51,12 @@ func (c *Camera2D) SetPosition(x float32, y float32) {
 // SetZoom sets the zoom factor
 func (c *Camera2D) SetZoom(zoom float32) {
 	c.zoom = zoom
+	c.matrixDirty = true
+}
+
+// SetCentered sets the center of the camera to the center of the screen
+func (c *Camera2D) SetCentered(centered bool) {
+	c.centered = centered
 	c.matrixDirty = true
 }
 

--- a/pkg/graphics/camera_2d_test.go
+++ b/pkg/graphics/camera_2d_test.go
@@ -6,24 +6,8 @@ import (
 	"github.com/go-gl/mathgl/mgl32"
 )
 
-func TestCenteredCamera2D(t *testing.T) {
-	c := NewCamera2D(100, 100, 1, true)
-
-	c.SetPosition(10, 10)
-	expected := mgl32.Mat4FromRows(mgl32.Vec4{0.02, 0, 0, -0.2}, mgl32.Vec4{0, -0.02, 0, 0.2}, mgl32.Vec4{0, 0, 0.5, 0}, mgl32.Vec4{0, 0, 0, 1})
-	if !c.ProjectionMatrix().ApproxEqual(expected) {
-		t.Errorf("SetPosition failed\nexpected\n%s received\n%s", expected.String(), c.projectionMatrix.String())
-	}
-
-	c.SetZoom(5)
-	expected = mgl32.Mat4FromRows(mgl32.Vec4{0.1, 0, 0, -1}, mgl32.Vec4{0, -0.1, 0, 1}, mgl32.Vec4{0, 0, 0.5, 0}, mgl32.Vec4{0, 0, 0, 1})
-	if !c.ProjectionMatrix().ApproxEqual(expected) {
-		t.Errorf("SetZoom failed\nexpected\n%s received\n%s", expected.String(), c.projectionMatrix.String())
-	}
-}
-
 func TestCamera2D(t *testing.T) {
-	c := NewCamera2D(100, 100, 10, false)
+	c := NewCamera2D(100, 100, 10)
 
 	c.SetPosition(10, 10)
 	expected := mgl32.Mat4FromRows(mgl32.Vec4{0.2, 0, 0, -3}, mgl32.Vec4{0, -0.2, 0, 3}, mgl32.Vec4{0, 0, 0.5, 0}, mgl32.Vec4{0, 0, 0, 1})
@@ -37,10 +21,24 @@ func TestCamera2D(t *testing.T) {
 		t.Errorf("SetZoom failed\nexpected\n%s received\n%s", expected.String(), c.projectionMatrix.String())
 	}
 
+	// Centered
+	c.SetCentered(true)
+	expected = mgl32.Mat4FromRows(mgl32.Vec4{0.1, 0, 0, -1}, mgl32.Vec4{0, -0.1, 0, 1}, mgl32.Vec4{0, 0, 0.5, 0}, mgl32.Vec4{0, 0, 0, 1})
+	if !c.ProjectionMatrix().ApproxEqual(expected) {
+		t.Errorf("SetCentered failed\nexpected\n%s received\n%s", expected.String(), c.projectionMatrix.String())
+	}
+
+	// Flipped and centered
 	c.SetFlipVertical(true)
-	expected = mgl32.Mat4FromRows(mgl32.Vec4{0.1, 0, 0, -2}, mgl32.Vec4{0, 0.1, 0, -2}, mgl32.Vec4{0, 0, 0.5, 0}, mgl32.Vec4{0, 0, 0, 1})
+	expected = mgl32.Mat4FromRows(mgl32.Vec4{0.1, 0, 0, -1}, mgl32.Vec4{0, 0.1, 0, -1}, mgl32.Vec4{0, 0, 0.5, 0}, mgl32.Vec4{0, 0, 0, 1})
 	if !c.ProjectionMatrix().ApproxEqual(expected) {
 		t.Errorf("SetFlipVertical failed\nexpected\n%s received\n%s", expected.String(), c.projectionMatrix.String())
 	}
 
+	// Flipped and not centered
+	c.SetCentered(false)
+	expected = mgl32.Mat4FromRows(mgl32.Vec4{0.1, 0, 0, -2}, mgl32.Vec4{0, 0.1, 0, -2}, mgl32.Vec4{0, 0, 0.5, 0}, mgl32.Vec4{0, 0, 0, 1})
+	if !c.ProjectionMatrix().ApproxEqual(expected) {
+		t.Errorf("SetFlipVertical failed\nexpected\n%s received\n%s", expected.String(), c.projectionMatrix.String())
+	}
 }


### PR DESCRIPTION
Small change that moves the centering (just like the V flip) to the Camera.
The app.Init() method doesn't handle it anymore